### PR TITLE
Added 'hyph' to prevent hyphenation (from McClass)

### DIFF
--- a/R/mathml.R
+++ b/R/mathml.R
@@ -936,3 +936,7 @@ under <- identity
 #' @rdname decorations
 #' @export
 underover <- identity
+
+#' @rdname decorations
+#' @export
+hyph<- identity

--- a/R/mathml.R
+++ b/R/mathml.R
@@ -928,7 +928,6 @@ tilde <- identity
 #' @export
 over <- identity
 
-
 #' @rdname decorations
 #' @export
 under <- identity

--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -447,10 +447,12 @@ math(hyph(L, R), M, _Flags)
 ml(hyph(L, R), M, Flags)
  => ml(L, X, Flags),
     ml(R, Y, Flags),
-    M = mtext([mi(X), &('#8209'), Y]). 
+    M = mtext([X, &('#8209'), Y]). 
 
 jax(hyph(L, R), M, _Flags)
- => format(string(M), "\\mbox{~w}{-}{~w}", [L, R]). 
+ => jax(L, X, _Flags),
+    jax(R, Y, _Flags),
+    format(string(M), "\\mbox{{~w}{-}{~w}}", [X, Y]). 
 
 % Strings are translated to upright text
 math(R, M),

--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -438,6 +438,20 @@ jax(underover(A, B, C), M, Flags)
     jax(C, Z, Flags),
     format(string(M), "{~w}/limits_{~w}^{~w}", [X, Y, Z]).
 
+%
+% Hyphen
+%
+math(hyph(L, R), M, _Flags)
+ =>  M = hyph(L, R).
+
+ml(hyph(L, R), M, Flags)
+ => ml(L, X, Flags),
+    ml(R, Y, Flags),
+    M = mtext([L, &('#8209'), R]). 
+
+jax(hyph(L, R), M, _Flags)
+ => format(string(M), "\\mbox{~w}{-}{~w}", [L, R]). 
+
 % Strings are translated to upright text
 math(R, M),
     string(R)

--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -447,7 +447,7 @@ math(hyph(L, R), M, _Flags)
 ml(hyph(L, R), M, Flags)
  => ml(L, X, Flags),
     ml(R, Y, Flags),
-    M = mtext([L, &('#8209'), R]). 
+    M = mtext([mi(L), &('#8209'), R]). 
 
 jax(hyph(L, R), M, _Flags)
  => format(string(M), "\\mbox{~w}{-}{~w}", [L, R]). 

--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -447,7 +447,7 @@ math(hyph(L, R), M, _Flags)
 ml(hyph(L, R), M, Flags)
  => ml(L, X, Flags),
     ml(R, Y, Flags),
-    M = mtext([mi(L), &('#8209'), R]). 
+    M = mtext([mi(X), &('#8209'), Y]). 
 
 jax(hyph(L, R), M, _Flags)
  => format(string(M), "\\mbox{~w}{-}{~w}", [L, R]). 

--- a/man/decorations.Rd
+++ b/man/decorations.Rd
@@ -11,6 +11,7 @@
 \alias{over}
 \alias{under}
 \alias{underover}
+\alias{hyph}
 \title{Identity functions for different decorations}
 \usage{
 roof(x)
@@ -30,6 +31,8 @@ over(x)
 under(x)
 
 underover(x)
+
+hyph(x)
 }
 \arguments{
 \item{x}{the expression to render}


### PR DESCRIPTION
-Unlike the original McClass-version, the left-element is not rendered in italics, so there is no difference between the two 't' in 't-test'.


-The 'mbox' in jax should  prevent hyphenation by putting the elements into a box

Source:   https://codeyarns.com/tech/2012-11-05-prevent-hyphenation-of-a-word-in-latex.html#gsc.tab=0