### PR TITLE
Moving 'pval' to separate file and updating bussproofs.pl

### DIFF
--- a/inst/pl/bussproofs.html
+++ b/inst/pl/bussproofs.html
@@ -1,0 +1,435 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+  <mrow semantics="bspr_inference:1;bspr_proof:true;bspr_labelledRule:right">
+    <mrow>
+      <mspace width="7.803em"></mspace>
+      <mrow>
+        <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+          <mtr>
+            <mtd>
+              <mtable framespacing="0 0">
+                <mtr>
+                  <mtd rowalign="bottom">
+                    <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
+                      <mrow>
+                        <mspace width="-7.803em"></mspace>
+                        <mrow>
+                          <mspace width="7.803em"></mspace>
+                          <mrow>
+                            <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                              <mtr>
+                                <mtd>
+                                  <mtable framespacing="0 0">
+                                    <mtr>
+                                      <mtd rowalign="bottom">
+                                        <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                          <mrow>
+                                            <mspace width="-7.803em"></mspace>
+                                            <mrow>
+                                              <mspace width="2.608em"></mspace>
+                                              <mrow>
+                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                  <mtr>
+                                                    <mtd>
+                                                      <mtable framespacing="0 0">
+                                                        <mtr>
+                                                          <mtd rowalign="bottom">
+                                                            <mrow semantics="bspr_inference:1;bspr_labelledRule:right">
+                                                              <mspace width="-2.608em"></mspace>
+                                                              <mrow>
+                                                                <mspace width="2.608em"></mspace>
+                                                                <mrow>
+                                                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                    <mtr>
+                                                                      <mtd>
+                                                                        <mtable framespacing="0 0">
+                                                                          <mtr>
+                                                                            <mtd rowalign="bottom">
+                                                                              <mrow semantics="bspr_inference:2;bspr_labelledRule:right">
+                                                                                <mrow>
+                                                                                  <mspace width="-2.608em"></mspace>
+                                                                                  <mrow>
+                                                                                    <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                                      <mtr>
+                                                                                        <mtd>
+                                                                                          <mtable framespacing="0 0">
+                                                                                            <mtr>
+                                                                                              <mtd rowalign="bottom">
+                                                                                                <mrow semantics="bspr_labelledRule:right;bspr_inference:0">
+                                                                                                  <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                                                    <mtr>
+                                                                                                      <mtd>
+                                                                                                        <mtable framespacing="0 0">
+                                                                                                          <mtr>
+                                                                                                            <mtd rowalign="bottom">
+                                                                                                              <mrow semantics="bspr_axiom:true"></mrow>
+                                                                                                            </mtd>
+                                                                                                          </mtr>
+                                                                                                        </mtable>
+                                                                                                      </mtd>
+                                                                                                    </mtr>
+                                                                                                    <mtr>
+                                                                                                      <mtd>
+                                                                                                        <mrow>
+                                                                                                          <mspace width=".5ex"></mspace>
+                                                                                                          <mstyle displaystyle="false" scriptlevel="0">
+                                                                                                            <mrow data-mjx-texclass="ORD">
+                                                                                                              <mi>A</mi>
+                                                                                                              <mo>&#x22A2;</mo>
+                                                                                                              <mi>A</mi>
+                                                                                                              <mo>,</mo>
+                                                                                                              <mi>B</mi>
+                                                                                                            </mrow>
+                                                                                                          </mstyle>
+                                                                                                          <mspace width=".5ex"></mspace>
+                                                                                                        </mrow>
+                                                                                                      </mtd>
+                                                                                                    </mtr>
+                                                                                                  </mtable>
+                                                                                                  <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                                                                                    <mstyle displaystyle="false" scriptlevel="0">
+                                                                                                      <mrow data-mjx-texclass="ORD">
+                                                                                                        <mstyle mathsize="0.7em">
+                                                                                                          <mrow data-mjx-texclass="ORD">
+                                                                                                            <mi>A</mi>
+                                                                                                            <mi>x</mi>
+                                                                                                            <mo>.</mo>
+                                                                                                          </mrow>
+                                                                                                        </mstyle>
+                                                                                                      </mrow>
+                                                                                                    </mstyle>
+                                                                                                  </mpadded>
+                                                                                                </mrow>
+                                                                                              </mtd>
+                                                                                              <mtd></mtd>
+                                                                                              <mtd rowalign="bottom">
+                                                                                                <mrow semantics="bspr_inference:0;bspr_labelledRule:right">
+                                                                                                  <mrow>
+                                                                                                    <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                                                      <mtr>
+                                                                                                        <mtd>
+                                                                                                          <mtable framespacing="0 0">
+                                                                                                            <mtr>
+                                                                                                              <mtd rowalign="bottom">
+                                                                                                                <mrow semantics="bspr_axiom:true"></mrow>
+                                                                                                              </mtd>
+                                                                                                            </mtr>
+                                                                                                          </mtable>
+                                                                                                        </mtd>
+                                                                                                      </mtr>
+                                                                                                      <mtr>
+                                                                                                        <mtd>
+                                                                                                          <mrow>
+                                                                                                            <mspace width=".5ex"></mspace>
+                                                                                                            <mstyle displaystyle="false" scriptlevel="0">
+                                                                                                              <mrow data-mjx-texclass="ORD">
+                                                                                                                <mi>B</mi>
+                                                                                                                <mo>,</mo>
+                                                                                                                <mi>A</mi>
+                                                                                                                <mo>&#x22A2;</mo>
+                                                                                                                <mi>B</mi>
+                                                                                                              </mrow>
+                                                                                                            </mstyle>
+                                                                                                            <mspace width=".5ex"></mspace>
+                                                                                                          </mrow>
+                                                                                                        </mtd>
+                                                                                                      </mtr>
+                                                                                                    </mtable>
+                                                                                                    <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                                                                                      <mstyle displaystyle="false" scriptlevel="0">
+                                                                                                        <mrow data-mjx-texclass="ORD">
+                                                                                                          <mstyle mathsize="0.7em">
+                                                                                                            <mrow data-mjx-texclass="ORD">
+                                                                                                              <mi>A</mi>
+                                                                                                              <mi>x</mi>
+                                                                                                              <mo>.</mo>
+                                                                                                            </mrow>
+                                                                                                          </mstyle>
+                                                                                                        </mrow>
+                                                                                                      </mstyle>
+                                                                                                    </mpadded>
+                                                                                                  </mrow>
+                                                                                                  <mspace width="-1.62em"></mspace>
+                                                                                                </mrow>
+                                                                                              </mtd>
+                                                                                            </mtr>
+                                                                                          </mtable>
+                                                                                        </mtd>
+                                                                                      </mtr>
+                                                                                      <mtr>
+                                                                                        <mtd>
+                                                                                          <mrow>
+                                                                                            <mspace width=".5ex"></mspace>
+                                                                                            <mstyle displaystyle="false" scriptlevel="0">
+                                                                                              <mrow data-mjx-texclass="ORD">
+                                                                                                <mi>A</mi>
+                                                                                                <mo>,</mo>
+                                                                                                <mi>A</mi>
+                                                                                                <mo accent="false" stretchy="false">&#x2192;</mo>
+                                                                                                <mi>B</mi>
+                                                                                                <mo>&#x22A2;</mo>
+                                                                                                <mi>B</mi>
+                                                                                              </mrow>
+                                                                                            </mstyle>
+                                                                                            <mspace width=".5ex"></mspace>
+                                                                                          </mrow>
+                                                                                        </mtd>
+                                                                                      </mtr>
+                                                                                    </mtable>
+                                                                                    <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                                                                      <mstyle displaystyle="false" scriptlevel="0">
+                                                                                        <mrow data-mjx-texclass="ORD">
+                                                                                          <mstyle mathsize="0.7em">
+                                                                                            <mrow data-mjx-texclass="ORD">
+                                                                                              <mi>L</mi>
+                                                                                              <mo accent="false" stretchy="false">&#x2192;</mo>
+                                                                                            </mrow>
+                                                                                          </mstyle>
+                                                                                        </mrow>
+                                                                                      </mstyle>
+                                                                                    </mpadded>
+                                                                                  </mrow>
+                                                                                </mrow>
+                                                                                <mspace width="-4.479em"></mspace>
+                                                                              </mrow>
+                                                                            </mtd>
+                                                                          </mtr>
+                                                                        </mtable>
+                                                                      </mtd>
+                                                                    </mtr>
+                                                                    <mtr>
+                                                                      <mtd>
+                                                                        <mrow>
+                                                                          <mspace width=".5ex"></mspace>
+                                                                          <mstyle displaystyle="false" scriptlevel="0">
+                                                                            <mrow data-mjx-texclass="ORD">
+                                                                              <mi>A</mi>
+                                                                              <mo accent="false" stretchy="false">&#x2192;</mo>
+                                                                              <mi>B</mi>
+                                                                              <mo>&#x22A2;</mo>
+                                                                              <mi mathvariant="normal">&#xAC;</mi>
+                                                                              <mi>A</mi>
+                                                                              <mo>,</mo>
+                                                                              <mi>B</mi>
+                                                                            </mrow>
+                                                                          </mstyle>
+                                                                          <mspace width=".5ex"></mspace>
+                                                                        </mrow>
+                                                                      </mtd>
+                                                                    </mtr>
+                                                                  </mtable>
+                                                                  <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                                                    <mstyle displaystyle="false" scriptlevel="0">
+                                                                      <mrow data-mjx-texclass="ORD">
+                                                                        <mstyle mathsize="0.7em">
+                                                                          <mrow data-mjx-texclass="ORD">
+                                                                            <mi>R</mi>
+                                                                            <mi mathvariant="normal">&#xAC;</mi>
+                                                                          </mrow>
+                                                                        </mstyle>
+                                                                      </mrow>
+                                                                    </mstyle>
+                                                                  </mpadded>
+                                                                </mrow>
+                                                              </mrow>
+                                                            </mrow>
+                                                          </mtd>
+                                                          <mtd>
+                                                            <mspace width="2.9807777777777775em"></mspace>
+                                                          </mtd>
+                                                          <mtd rowalign="bottom">
+                                                            <mrow semantics="bspr_inference:0;bspr_labelledRule:right">
+                                                              <mrow>
+                                                                <mtable align="top 2" rowlines="solid" framespacing="0 0" semantics="bspr_inferenceRule:down">
+                                                                  <mtr>
+                                                                    <mtd>
+                                                                      <mtable framespacing="0 0">
+                                                                        <mtr>
+                                                                          <mtd rowalign="bottom">
+                                                                            <mrow semantics="bspr_axiom:true"></mrow>
+                                                                          </mtd>
+                                                                        </mtr>
+                                                                      </mtable>
+                                                                    </mtd>
+                                                                  </mtr>
+                                                                  <mtr>
+                                                                    <mtd>
+                                                                      <mrow>
+                                                                        <mspace width=".5ex"></mspace>
+                                                                        <mstyle displaystyle="false" scriptlevel="0">
+                                                                          <mrow data-mjx-texclass="ORD">
+                                                                            <mi>B</mi>
+                                                                            <mo>,</mo>
+                                                                            <mi>A</mi>
+                                                                            <mo accent="false" stretchy="false">&#x2192;</mo>
+                                                                            <mi>B</mi>
+                                                                            <mo>&#x22A2;</mo>
+                                                                            <mi>B</mi>
+                                                                          </mrow>
+                                                                        </mstyle>
+                                                                        <mspace width=".5ex"></mspace>
+                                                                      </mrow>
+                                                                    </mtd>
+                                                                  </mtr>
+                                                                </mtable>
+                                                                <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                                                  <mstyle displaystyle="false" scriptlevel="0">
+                                                                    <mrow data-mjx-texclass="ORD">
+                                                                      <mstyle mathsize="0.7em">
+                                                                        <mrow data-mjx-texclass="ORD">
+                                                                          <mi>A</mi>
+                                                                          <mi>x</mi>
+                                                                          <mo>.</mo>
+                                                                        </mrow>
+                                                                      </mstyle>
+                                                                    </mrow>
+                                                                  </mstyle>
+                                                                </mpadded>
+                                                              </mrow>
+                                                              <mspace width="-1.62em"></mspace>
+                                                            </mrow>
+                                                          </mtd>
+                                                        </mtr>
+                                                      </mtable>
+                                                    </mtd>
+                                                  </mtr>
+                                                  <mtr>
+                                                    <mtd>
+                                                      <mrow>
+                                                        <mspace width=".5ex"></mspace>
+                                                        <mstyle displaystyle="false" scriptlevel="0">
+                                                          <mrow data-mjx-texclass="ORD">
+                                                            <mi mathvariant="normal">&#xAC;</mi>
+                                                            <mi>A</mi>
+                                                            <mo accent="false" stretchy="false">&#x2192;</mo>
+                                                            <mi>B</mi>
+                                                            <mo>,</mo>
+                                                            <mi>A</mi>
+                                                            <mo accent="false" stretchy="false">&#x2192;</mo>
+                                                            <mi>B</mi>
+                                                            <mo>&#x22A2;</mo>
+                                                            <mi>B</mi>
+                                                          </mrow>
+                                                        </mstyle>
+                                                        <mspace width=".5ex"></mspace>
+                                                      </mrow>
+                                                    </mtd>
+                                                  </mtr>
+                                                </mtable>
+                                                <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                                                  <mstyle displaystyle="false" scriptlevel="0">
+                                                    <mrow data-mjx-texclass="ORD">
+                                                      <mstyle mathsize="0.7em">
+                                                        <mrow data-mjx-texclass="ORD">
+                                                          <mi>L</mi>
+                                                          <mo accent="false" stretchy="false">&#x2192;</mo>
+                                                        </mrow>
+                                                      </mstyle>
+                                                    </mrow>
+                                                  </mstyle>
+                                                </mpadded>
+                                              </mrow>
+                                            </mrow>
+                                          </mrow>
+                                          <mspace width="-7.066em"></mspace>
+                                        </mrow>
+                                      </mtd>
+                                    </mtr>
+                                  </mtable>
+                                </mtd>
+                              </mtr>
+                              <mtr>
+                                <mtd>
+                                  <mrow>
+                                    <mspace width=".5ex"></mspace>
+                                    <mstyle displaystyle="false" scriptlevel="0">
+                                      <mrow data-mjx-texclass="ORD">
+                                        <mo stretchy="false">(</mo>
+                                        <mi mathvariant="normal">&#xAC;</mi>
+                                        <mi>A</mi>
+                                        <mo accent="false" stretchy="false">&#x2192;</mo>
+                                        <mi>B</mi>
+                                        <mo stretchy="false">)</mo>
+                                        <mo>&#x2227;</mo>
+                                        <mo stretchy="false">(</mo>
+                                        <mi>A</mi>
+                                        <mo accent="false" stretchy="false">&#x2192;</mo>
+                                        <mi>B</mi>
+                                        <mo stretchy="false">)</mo>
+                                        <mo>&#x22A2;</mo>
+                                        <mi>B</mi>
+                                      </mrow>
+                                    </mstyle>
+                                    <mspace width=".5ex"></mspace>
+                                  </mrow>
+                                </mtd>
+                              </mtr>
+                            </mtable>
+                            <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+                              <mstyle displaystyle="false" scriptlevel="0">
+                                <mrow data-mjx-texclass="ORD">
+                                  <mstyle mathsize="0.7em">
+                                    <mrow data-mjx-texclass="ORD">
+                                      <mi>L</mi>
+                                      <mo>&#x2227;</mo>
+                                    </mrow>
+                                  </mstyle>
+                                </mrow>
+                              </mstyle>
+                            </mpadded>
+                          </mrow>
+                        </mrow>
+                      </mrow>
+                      <mspace width="-1.444em"></mspace>
+                    </mrow>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mtd>
+          </mtr>
+          <mtr>
+            <mtd>
+              <mrow>
+                <mspace width=".5ex"></mspace>
+                <mstyle displaystyle="false" scriptlevel="0">
+                  <mrow data-mjx-texclass="ORD">
+                    <mo>&#x22A2;</mo>
+                    <mo stretchy="false">(</mo>
+                    <mo stretchy="false">(</mo>
+                    <mi mathvariant="normal">&#xAC;</mi>
+                    <mi>A</mi>
+                    <mo accent="false" stretchy="false">&#x2192;</mo>
+                    <mi>B</mi>
+                    <mo stretchy="false">)</mo>
+                    <mo>&#x2227;</mo>
+                    <mo stretchy="false">(</mo>
+                    <mi>A</mi>
+                    <mo accent="false" stretchy="false">&#x2192;</mo>
+                    <mi>B</mi>
+                    <mo stretchy="false">)</mo>
+                    <mo stretchy="false">)</mo>
+                    <mo accent="false" stretchy="false">&#x2192;</mo>
+                    <mi>B</mi>
+                  </mrow>
+                </mstyle>
+                <mspace width=".5ex"></mspace>
+              </mrow>
+            </mtd>
+          </mtr>
+        </mtable>
+        <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+          <mstyle displaystyle="false" scriptlevel="0">
+            <mrow data-mjx-texclass="ORD">
+              <mstyle mathsize="0.7em">
+                <mrow data-mjx-texclass="ORD">
+                  <mi>R</mi>
+                  <mo accent="false" stretchy="false">&#x2192;</mo>
+                </mrow>
+              </mstyle>
+            </mrow>
+          </mstyle>
+        </mpadded>
+      </mrow>
+    </mrow>
+    <mspace width="-0.482em"></mspace>
+  </mrow>
+</math>

--- a/inst/pl/bussproofs.pl
+++ b/inst/pl/bussproofs.pl
@@ -38,6 +38,24 @@ mlx(rcond(A, B), M, Flags) :-
     ml(mpadded_right(R3), R4, Flags),
     M = mrow([F2, R4]).  
 
+mlx(ror(A, B), M, Flags) :-
+    ml(proof(A, B), F1, Flags),
+    ml(proof_tree(F1), F2, Flags),
+    ml(or('R', ''), R1, Flags),
+    ml(size(R1, '0.7em'), R2, Flags),
+    ml(mstyle_right(R2), R3, Flags),
+    ml(mpadded_right(R3), R4, Flags),
+    M = mrow([F2, R4]). 
+
+mlx(rneg(A, B), M, Flags) :-
+    ml(proof(A, B), F1, Flags),
+    ml(proof_tree(F1), F2, Flags),
+    ml(!('R',''), R1, Flags),
+    ml(size(R1, '0.7em'), R2, Flags),
+    ml(mstyle_right(R2), R3, Flags),
+    ml(mpadded_right(R3), R4, Flags),
+    M = mrow([F2, R4]). 
+
 mlx(land(A, B), M, Flags) :-
     ml(proof(A, B), F1, Flags),
     ml(proof_tree(F1), F2, Flags),

--- a/inst/pl/bussproofs.pl
+++ b/inst/pl/bussproofs.pl
@@ -20,6 +20,10 @@ mlx(proof(Denominator, Numerator), X, _Flags) :-
     X1 =.. ['###1', '##'(Numerator)],
     X =.. ['###2', '##'(X1), '##1'(Denominator)].
 
+mlx(proof(Denominator, Numerator1, Numerator2), X, _Flags) :-
+    X1 =.. ['###1', '##'(Numerator1, '', Numerator2)],
+    X =.. ['###2', '##'(X1), '##1'(Denominator)].
+
 mlx(size(A, Size), M, _Flags) :-
     M = mrow([mstyle([mathsize(Size)], A)]).
 
@@ -55,6 +59,24 @@ mlx(rneg(A, B), M, Flags) :-
     ml(mstyle_right(R2), R3, Flags),
     ml(mpadded_right(R3), R4, Flags),
     M = mrow([F2, R4]). 
+
+mlx(lcond(A, B), M, Flags) :-
+    ml(proof(A, B), F1, Flags),
+    ml(proof_tree(F1), F2, Flags),
+    ml('%->%'('L', ''), R1, Flags),
+    ml(size(R1, '0.7em'), R2, Flags),
+    ml(mstyle_right(R2), R3, Flags),
+    ml(mpadded_right(R3), R4, Flags),
+    M = mrow([F2, R4]).  
+
+mlx(lcond(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F1, Flags),
+    ml(proof_tree(F1), F2, Flags),
+    ml('%->%'('L', ''), R1, Flags),
+    ml(size(R1, '0.7em'), R2, Flags),
+    ml(mstyle_right(R2), R3, Flags),
+    ml(mpadded_right(R3), R4, Flags),
+    M = mrow([F2, R4]).  
 
 mlx(land(A, B), M, Flags) :-
     ml(proof(A, B), F1, Flags),

--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -975,7 +975,7 @@ math(or(A, B), M)
     M = xfy(Prec, or, A, B).
 
 math(!(A), M)
- => current(Prec, xfy, ^),
+ => current(Prec, xfy, ','),
     M = fy(Prec, not, A).
 
 math(!(A, B), M)
@@ -1849,7 +1849,8 @@ math('%<=>%'(A, B), X)
 
 math('%->%'(A, B), X)
  => current_op(Prec, xfy, ->),
-    X = yfy(Prec, '%->%', A, B).
+    Prec1 is Prec - 50,
+    X = yfy(Prec1, '%->%', A, B).
 
 math('%=>%'(A, B), X)
  => current_op(Prec, xfy, ->),

--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -978,6 +978,10 @@ math(!(A), M)
  => current(Prec, xfy, ^),
     M = fy(Prec, not, A).
 
+math(!(A, B), M)
+ => current(Prec, xfy, ^),
+    M = xfy(Prec, not, A, B).
+
 math(xor(x=A, y=B), M)
  => M = xor(A, B).
 
@@ -1647,6 +1651,9 @@ jax(op(and), M, _Flags)
 ml(op(or), M, _Flags)
  => M = mo(&(or)).
 
+ml(op('%|%'), M, _Flags)
+ => M = mo(&(or)).
+
 jax(op(or), M, _Flags)
  => M = "\\lor".
 
@@ -1655,6 +1662,9 @@ ml(op(not), M, _Flags)
 
 jax(op(not), M, _Flags)
  => M = "\\lnot".
+
+ml(op(~), M, _Flags)
+ => M = mo(&(not)).
 
 ml(op(veebar), M, _Flags)
  => M = mo(&(veebar)).
@@ -1890,6 +1900,16 @@ math('%,%'(A, B), X)
  => current_op(Prec1, xfy, ','),
     Prec is Prec1 - 1,
     X = yfy(Prec, '%,%', A, B).
+
+math('%|%'(A, B), X)
+ => current_op(Prec1, xfy, ','),
+    Prec is Prec1 - 1,
+    X = yfy(Prec, '%|%', A, B).
+
+math(~(A), X)
+ => current_op(Prec1, xfy, ','),
+    Prec is Prec1 - 1,
+    X = fy(Prec, ~, A).
 
 math(A > B, X)
  => current_op(Prec, xfx, >),

--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -13,6 +13,8 @@
 %
 :- dynamic math_hook/2.
 :- multifile math_hook/2.
+:- multifile math/4.
+:- multifile math/3.
 
 % Low-level functions (see, e.g. nthroot.pl)
 %
@@ -1778,34 +1780,6 @@ math(number(A), M),
 
 math(number(A), M)
  => M = pos(A).
-
-% p-value
-math(pval(A), M, Flags, Flags1),
-    type(A, T, Flags),
-    member(numeric(N), T),
-    N =< 1,
-    N >= 0.1
- => M = A,
-    Flags1 = [round(2) | Flags].
-
-math(pval(A), M, Flags, Flags1),
-    type(A, T, Flags),
-    member(numeric(_N), T)
- => M = A,
-    Flags1 = [round(3) | Flags].
-
-math(pval(A), M, Flags, Flags1)
- => M = A,
-    Flags1 = Flags.
-
-math(pval(A, P), M, Flags),
-    type(A, T, Flags),
-    member(numeric(N), T),
-    N < 0.001
- => M = (P < pval(0.001)).
-
-math(pval(A, P), M, _Flags)
- => M = (P == pval(A)).
 
 % Operators
 math(isin(A, B), X)

--- a/inst/pl/pval.pl
+++ b/inst/pl/pval.pl
@@ -53,5 +53,5 @@ math(pval(A, P), M, Flags) :-
     N < 0.001,
     M = (P < pval(0.001)).
 
-math(pval(A, P), M), _Flags :-
+math(pval(A, P), M, _Flags) :-
     M = (P == pval(A)). */

--- a/inst/pl/pval.pl
+++ b/inst/pl/pval.pl
@@ -1,0 +1,57 @@
+% p-value
+math(pval(A), M, Flags, Flags1),
+    type(A, T, Flags),
+    member(numeric(N), T),
+    N =< 1,
+    N >= 0.1
+ => M = A,
+    Flags1 = [round(2) | Flags].
+
+math(pval(A), M, Flags, Flags1),
+    type(A, T, Flags),
+    member(numeric(_N), T)
+ => M = A,
+    Flags1 = [round(3) | Flags].
+
+math(pval(A), M, Flags, Flags1)
+ => M = A,
+    Flags1 = Flags.
+
+math(pval(A, P), M, Flags),
+    type(A, T, Flags),
+    member(numeric(N), T),
+    N < 0.001
+ => M = (P < pval(0.001)).
+
+math(pval(A, P), M, _Flags)
+ => M = (P == pval(A)).
+
+
+/* 
+% p-value
+math(pval(A), M, Flags, Flags1) :-
+    type(A, T, Flags),
+    member(numeric(N), T),
+    N =< 1,
+    N >= 0.1,
+    M = A,
+    Flags1 = [round(2) | Flags].
+
+math(pval(A), M, Flags, Flags1) :-
+    type(A, T, Flags),
+    member(numeric(_N), T),
+    M = A,
+    Flags1 = [round(3) | Flags].
+
+math(pval(A), M, Flags, Flags1) :- 
+    M = A,
+    Flags1 = Flags.
+
+math(pval(A, P), M, Flags) :-
+    type(A, T, Flags),
+    member(numeric(N), T),
+    N < 0.001,
+    M = (P < pval(0.001)).
+
+math(pval(A, P), M), _Flags :-
+    M = (P == pval(A)). */


### PR DESCRIPTION
The predicate is not found yet:

![image](https://github.com/mgondan/mathml/assets/149394139/e0855f42-1c22-4f87-9f0b-c7b9e75679b8)


And I'm not sure if making 'math/3' and 'math/4' multifile is right approach.

In the other file (nthroot.pl, lm.pl) there was the predicate 'math_hook/2', which only takes two arguments, but we need the flags for the rounding ...