### PR TITLE
Updated precedence of operators and added new predicates for bussproofs.pl

### DIFF
--- a/inst/pl/bussproofs.pl
+++ b/inst/pl/bussproofs.pl
@@ -96,6 +96,15 @@ mlx(ax(A, B), M, Flags) :-
     ml(mpadded_right(R3), R4, Flags),
     M = mrow([F2, R4]).
 
+mlx(asq(A, B), M, Flags) :-
+    ml(proof(A, B), F1, Flags),
+    ml(proof_tree(F1), F2, Flags),
+    ml(ident('Asq.'), R1, [mathvariant(italic)]),
+    ml(size(R1, '0.7em'), R2, Flags),
+    ml(mstyle_right(R2), R3, Flags),
+    ml(mpadded_right(R3), R4, Flags),
+    M = mrow([mathcolor(red)], [F2, R4]).
+
 % Render in MathJax
 % jaxx(rcond(A, B), M, Flags) :-
 %     jax(A, A1, Flags),

--- a/inst/pl/bussproofs.pl
+++ b/inst/pl/bussproofs.pl
@@ -87,6 +87,24 @@ mlx(land(A, B), M, Flags) :-
     ml(mpadded_right(R3), R4, Flags),
     M = mrow([F2, R4]).  
 
+mlx(lor(A, B), M, Flags) :-
+    ml(proof(A, B), F1, Flags),
+    ml(proof_tree(F1), F2, Flags),
+    ml(or('L', ''), R1, Flags),
+    ml(size(R1, '0.7em'), R2, Flags),
+    ml(mstyle_right(R2), R3, Flags),
+    ml(mpadded_right(R3), R4, Flags),
+    M = mrow([F2, R4]). 
+
+mlx(lor(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F1, Flags),
+    ml(proof_tree(F1), F2, Flags),
+    ml(or('L', ''), R1, Flags),
+    ml(size(R1, '0.7em'), R2, Flags),
+    ml(mstyle_right(R2), R3, Flags),
+    ml(mpadded_right(R3), R4, Flags),
+    M = mrow([F2, R4]). 
+    
 mlx(ax(A, B), M, Flags) :-
     ml(proof(A, B), F1, Flags),
     ml(proof_tree(F1), F2, Flags),

--- a/inst/pl/bussproofs.pl
+++ b/inst/pl/bussproofs.pl
@@ -16,13 +16,21 @@
 % math_hook(rcond(A, B), [frac(B, A), '%->%'('R', xx)]).
 
 % Render in MathML
-mlx(proof(Denominator, Numerator), X, _Flags) :-
+mlx(proof(Denominator, Numerator), M, Flags) :-
     X1 =.. ['###1', '##'(Numerator)],
-    X =.. ['###2', '##'(X1), '##1'(Denominator)].
+    X =.. ['###2', '##'(X1), '##1'(Denominator)],
+    ml(proof_tree(X), M, Flags).
 
-mlx(proof(Denominator, Numerator1, Numerator2), X, _Flags) :-
+mlx(proof(Denominator, Numerator1, Numerator2), M, Flags) :-
     X1 =.. ['###1', '##'(Numerator1, '', Numerator2)],
-    X =.. ['###2', '##'(X1), '##1'(Denominator)].
+    X =.. ['###2', '##'(X1), '##1'(Denominator)],
+    ml(proof_tree(X), M, Flags).
+
+mlx(format_operator(Op), R, Flags) :-
+    ml(Op, R1, Flags),
+    ml(size(R1, '0.7em'), R2, Flags),
+    ml(mstyle_right(R2), R3, Flags),
+    ml(mpadded_right(R3), R, Flags).
 
 mlx(size(A, Size), M, _Flags) :-
     M = mrow([mstyle([mathsize(Size)], A)]).
@@ -33,113 +41,115 @@ mlx(mstyle_right(A), M, _Flags) :-
 mlx(mpadded_right(A), M, _Flags) :-
     M = mpadded([height('.5em'), width('.5em'), voffset('.9em'), semantics('bspr_prooflabel:right')], A).
 
+mlx(rbicond(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator('%<->%'('R', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(rbicond(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator('%<->%'('R', '')), R, Flags),
+    M = mrow([F, R]).  
+
 mlx(rcond(A, B), M, Flags) :-
-    ml(proof(A, B), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml('%->%'('R', ''), R1, Flags),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([F2, R4]).  
+    ml(proof(A, B), F, Flags),
+    ml(format_operator('%->%'('R', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(rcond(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator('%->%'('R', '')), R, Flags),
+    M = mrow([F, R]).  
 
 mlx(rand(A, B), M, Flags) :-
-    ml(proof(A, B), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml(and('R', ''), R1, Flags),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([F2, R4]). 
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(and('R', '')), R, Flags),
+    M = mrow([F, R]). 
 
 mlx(rand(A, B, C), M, Flags) :-
-    ml(proof(A, B, C), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml(and('R', ''), R1, Flags),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([F2, R4]). 
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator(and('R', '')), R, Flags),
+    M = mrow([F, R]). 
     
 mlx(ror(A, B), M, Flags) :-
-    ml(proof(A, B), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml(or('R', ''), R1, Flags),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([F2, R4]). 
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(or('R', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(ror(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator(or('R', '')), R, Flags),
+    M = mrow([F, R]). 
 
 mlx(rneg(A, B), M, Flags) :-
-    ml(proof(A, B), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml(!('R',''), R1, Flags),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([F2, R4]). 
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(!('R','')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(rneg(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator(!('R','')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(lbicond(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator('%<->%'('L', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(lbicond(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator('%<->%'('L', '')), R, Flags),
+    M = mrow([F, R]).  
 
 mlx(lcond(A, B), M, Flags) :-
-    ml(proof(A, B), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml('%->%'('L', ''), R1, Flags),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([F2, R4]).  
+    ml(proof(A, B), F, Flags),
+    ml(format_operator('%->%'('L', '')), R, Flags),
+    M = mrow([F, R]).  
 
 mlx(lcond(A, B, C), M, Flags) :-
-    ml(proof(A, B, C), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml('%->%'('L', ''), R1, Flags),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([F2, R4]).  
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator('%->%'('L', '')), R, Flags),
+    M = mrow([F, R]).  
 
 mlx(land(A, B), M, Flags) :-
-    ml(proof(A, B), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml('&'('L', ''), R1, Flags),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([F2, R4]).  
+    ml(proof(A, B), F, Flags),
+    ml(format_operator('&'('L', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(land(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator('&'('L', '')), R, Flags),
+    M = mrow([F, R]).  
 
 mlx(lor(A, B), M, Flags) :-
-    ml(proof(A, B), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml(or('L', ''), R1, Flags),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([F2, R4]). 
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(or('L', '')), R, Flags),
+    M = mrow([F, R]). 
 
 mlx(lor(A, B, C), M, Flags) :-
-    ml(proof(A, B, C), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml(or('L', ''), R1, Flags),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([F2, R4]). 
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator(or('L', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(lneg(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(!('L', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(lneg(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator(!('L', '')), R, Flags),
+    M = mrow([F, R]). 
 
 mlx(ax(A, B), M, Flags) :-
-    ml(proof(A, B), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml(ident('Ax.'), R1, [mathvariant(italic)]),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([F2, R4]).
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(ident('Ax.')), R, [mathvariant(italic)]),
+    M = mrow([F, R]).
 
 mlx(asq(A, B), M, Flags) :-
-    ml(proof(A, B), F1, Flags),
-    ml(proof_tree(F1), F2, Flags),
-    ml(ident('Asq.'), R1, [mathvariant(italic)]),
-    ml(size(R1, '0.7em'), R2, Flags),
-    ml(mstyle_right(R2), R3, Flags),
-    ml(mpadded_right(R3), R4, Flags),
-    M = mrow([mathcolor(red)], [F2, R4]).
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(ident('Asq.')), R, [mathvariant(italic)]),
+    M = mrow([mathcolor(red)], [F, R]).
 
 % Render in MathJax
 % jaxx(rcond(A, B), M, Flags) :-

--- a/inst/pl/bussproofs.pl
+++ b/inst/pl/bussproofs.pl
@@ -42,6 +42,24 @@ mlx(rcond(A, B), M, Flags) :-
     ml(mpadded_right(R3), R4, Flags),
     M = mrow([F2, R4]).  
 
+mlx(rand(A, B), M, Flags) :-
+    ml(proof(A, B), F1, Flags),
+    ml(proof_tree(F1), F2, Flags),
+    ml(and('R', ''), R1, Flags),
+    ml(size(R1, '0.7em'), R2, Flags),
+    ml(mstyle_right(R2), R3, Flags),
+    ml(mpadded_right(R3), R4, Flags),
+    M = mrow([F2, R4]). 
+
+mlx(rand(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F1, Flags),
+    ml(proof_tree(F1), F2, Flags),
+    ml(and('R', ''), R1, Flags),
+    ml(size(R1, '0.7em'), R2, Flags),
+    ml(mstyle_right(R2), R3, Flags),
+    ml(mpadded_right(R3), R4, Flags),
+    M = mrow([F2, R4]). 
+    
 mlx(ror(A, B), M, Flags) :-
     ml(proof(A, B), F1, Flags),
     ml(proof_tree(F1), F2, Flags),
@@ -104,7 +122,7 @@ mlx(lor(A, B, C), M, Flags) :-
     ml(mstyle_right(R2), R3, Flags),
     ml(mpadded_right(R3), R4, Flags),
     M = mrow([F2, R4]). 
-    
+
 mlx(ax(A, B), M, Flags) :-
     ml(proof(A, B), F1, Flags),
     ml(proof_tree(F1), F2, Flags),

--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -1857,8 +1857,7 @@ math('%<=>%'(A, B), X)
 
 math('%->%'(A, B), X)
  => current_op(Prec, xfy, ->),
-    Prec1 is Prec - 50,
-    X = yfy(Prec1, '%->%', A, B).
+    X = yfy(Prec, '%->%', A, B).
 
 math('%=>%'(A, B), X)
  => current_op(Prec, xfy, ->),
@@ -1901,23 +1900,19 @@ math('%prop%'(A, B), X)
     X = yfy(Prec, '%prop%', A, B).
 
 math('%>%'(A, B), X)
- => current_op(Prec1, xfy, ','),
-    Prec is Prec1 - 1,
+ => current_op(Prec, xfy, ','),
     X = yfy(Prec, '%>%', A, B).
 
 math('%,%'(A, B), X)
- => current_op(Prec1, xfy, ','),
-    Prec is Prec1 - 1,
+ => current_op(Prec, xfy, ','),
     X = yfy(Prec, '%,%', A, B).
 
 math('%|%'(A, B), X)
- => current_op(Prec1, xfy, ','),
-    Prec is Prec1 - 1,
+ => current_op(Prec, xfy, ';'),
     X = yfy(Prec, '%|%', A, B).
 
 math(~(A), X)
- => current_op(Prec1, xfy, ','),
-    Prec is Prec1 - 1,
+ => current_op(Prec, fy, \+),
     X = fy(Prec, ~, A).
 
 math(A > B, X)

--- a/tests/test-bussproofs.Rmd
+++ b/tests/test-bussproofs.Rmd
@@ -1,0 +1,81 @@
+```{r}
+library(mathml)
+rolog::consult(system.file(file.path("pl", "bussproofs.pl"), package="mathml"))
+
+# 1. Excluded middle
+term <- quote(ror(''%>%A%|%~A, rneg(''%>%A%,%~A, ax(A%>%A,''))))
+#math(term)
+
+# 2. Dilemma
+term <- quote(rcond(''%>%((~A%->%B)&(A%->%B))%->%B, land((~A%->%B)&(A%->%B)%>%B, 
+lcond(~A%>%B%,%A%->%B%>%B, 
+rneg(A%->%B%>%~A%,%B, 
+lcond(A%,%A%->%B%>%B, 
+ax(A%>%A%,%B, ''), ax(B%,%A%>%B, ''))), 
+ax(B%,%A%->%B%>%B, '' )))))
+math(term)
+
+# 3. Double negation
+term <- quote(rbicond(''%>%~~A%<=>%A, 
+lneg(~~A%>%A, 
+rneg(''%>%~A%,%A, 
+ax(A%>%A, ''))), 
+rneg(A%>%~~A, 
+lneg(~A%,%A%>%'', 
+ax(A%>%A, '')))))
+math(term)
+
+# 4. Peirce's Law
+term <- quote(rcond(''%>%((A%->%B)%->%A)%->%A, 
+lcond((A%->%B)%->%A%>%A, 
+rcond(''%>%A%->%B%,%A, 
+ax(A%>%B%,%A, '')), 
+ax(A%>%A, ''))))
+math(term)
+
+# 5. Dummett Formula
+term <-quote(ror(''%>%(A%->%B)%|%(B%->%A), 
+rcond(''%>%A%->%B%,%B%->%A, 
+rcond(A%>%B%,%B%->%A, 
+ax(B%,%A%>%A%,%B, '')))))
+math(term)
+
+# 6. Classical equivalence for negation
+term <- quote(rbicond(''%>%(~A%->%A)%<=>%A, 
+lcond(~A%->%A%>%A, 
+rneg(''%>%~A%,%A, 
+ax(A%>%A, '')), 
+ax(A%>%A, '')), 
+rcond(A%>%~A%->%A, 
+ax(~A%,%A%>%A, ''))))
+math(term)
+
+# 7. Classical De Morgan's Law
+term <- quote(rcond(''%>%~(A&B)%->%(~A%|%~B), 
+ror(~(A&B)%>%~A%|%~B, 
+rneg(~(A&B)%>%~A%,%~B, 
+rneg(A%,%~(A&B)%>%~B, 
+lneg(B%,%A%,%~(A&B)%>%'', 
+rand(B%,%A%>%A&B, 
+ax(B%,%A%>%A, ''), 
+ax(B%,%A%>%B, ''))))))))
+math(term)
+
+# 9. a
+term <- quote(asq(''%<%A, ''))
+math(term)
+
+# 10. a => b
+term <- quote(rcond(''%>%A%->%B, asq(A%<%B, '')))
+math(term)
+
+# 11. (a | b) => (a & b)
+term <- quote(rcond(''%>%(A%|%B)%->%(A&B), 
+rand(A%|%B%>%A&B, 
+lor(A%|%B%>%A, ax(A%>%A, ''), 
+    asq(B%<%A, '')), 
+lor(A%|%B%>%B, asq(A%<%B, ''), 
+    ax(B%>%B, '')))))
+math(term)
+
+```

--- a/vignettes/mathml.Rmd
+++ b/vignettes/mathml.Rmd
@@ -874,6 +874,30 @@ math(term)
 term <- quote(rcond(''%>%(A&B)%=>%A, land(A&B%>%A, ax(A%,%B%>%A,''))))
 math(term)
 ```
+
+## P-value
+With pval/2, a value specified as first argument can be displayed with the following rounding rules:  
+
+0.1 < value < 1 : two digits  
+0.001 < value < 0.1 : three digits  
+value < 0.0001 : output defaults to "< 0.0001". 
+
+The identifier for the value is provided as second argument.
+
+```{r}
+library(mathml)
+rolog::consult(system.file(file.path("pl", "pval.pl"), package="mathml"))
+
+term <- quote(pval(0.539, P))
+math(term)
+
+term <- quote(pval(0.0137, p))
+math(term)
+
+term <- quote(pval(0.0003, P))
+math(term)
+
+```
 <br><br>
 
 # Acknowledgment


### PR DESCRIPTION
I changed the precedence of the operators according to our last email, but the one for the negation does not to seem right yet, because it is sometimes separated from the operand by a parentheses. 

![image](https://github.com/mgondan/mathml/assets/149394139/0cf61161-25c0-411d-89de-c333f3ced17a)


P.S. : before merging this request, I would like to add more commits with the additional predicates for bussproof.pl, so that there is no need to open another one.