### PR TITLE
Bussproofs: changing to prefix notation and migrating to Prolog package

### DIFF
--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -1902,6 +1902,10 @@ math('%prop%'(A, B), X)
  => current_op(Prec, xfx, =),
     X = yfy(Prec, '%prop%', A, B).
 
+math('%>%'(A), X)
+ => current_op(Prec, xfy, ','),
+    X = fy(Prec, '%>%', A).
+
 math('%>%'(A, B), X)
  => current_op(Prec, xfy, ','),
     X = yfy(Prec, '%>%', A, B).

--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -1910,6 +1910,10 @@ math('%>%'(A, B), X)
  => current_op(Prec, xfy, ','),
     X = yfy(Prec, '%>%', A, B).
 
+math('%<%'(A), X)
+ => current_op(Prec, xfy, ','),
+    X = fy(Prec, '%<%', A).
+
 math('%<%'(A, B), X)
  => current_op(Prec, xfy, ','),
     X = yfy(Prec, '%<%', A, B).

--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -1903,11 +1903,11 @@ math('%prop%'(A, B), X)
     X = yfy(Prec, '%prop%', A, B).
 
 math('%>%'(A), X)
- => current_op(Prec, xfy, ','),
+ => current_op(Prec, xfy, ';'),
     X = fy(Prec, '%>%', A).
 
 math('%>%'(A, B), X)
- => current_op(Prec, xfy, ','),
+ => current_op(Prec, xfy, ';'),
     X = yfy(Prec, '%>%', A, B).
 
 math('%<%'(A), X)

--- a/prolog/bussproofs.pl
+++ b/prolog/bussproofs.pl
@@ -1,0 +1,164 @@
+:- module(bussproofs, []).
+:- reexport(library(mathml)).
+
+:- multifile mlx/3. 
+
+% Render in MathML
+%
+%      <mpadded height="+.5em" width="+.5em" voffset="-.15em" semantics="bspr_prooflabel:right">
+%        <mstyle displaystyle="false" scriptlevel="0">
+%          <mrow data-mjx-texclass="ORD">
+%            <mstyle mathsize="0.7em">
+%              <mrow data-mjx-texclass="ORD">
+%                <mi>R</mi>
+%                <mo accent="false" stretchy="false">&#x2192;</mo>
+%              </mrow>
+%            </mstyle>
+%          </mrow>
+%        </mstyle>
+%      </mpadded>
+%
+% math_hook(rcond(A, B), [frac(B, A), '%->%'('R', xx)]).
+
+% Render in MathML
+mlx(proof(Denominator, Numerator), M, Flags) :-
+    X1 =.. ['###1', '##'(Numerator)],
+    X =.. ['###2', '##'(X1), '##1'(Denominator)],
+    ml(proof_tree(X), M, Flags).
+
+mlx(proof(Denominator, Numerator1, Numerator2), M, Flags) :-
+    X1 =.. ['###1', '##'(Numerator1, '', Numerator2)],
+    X =.. ['###2', '##'(X1), '##1'(Denominator)],
+    ml(proof_tree(X), M, Flags).
+
+mlx(format_operator(Op), R, Flags) :-
+    ml(Op, R1, Flags),
+    ml(size(R1, '0.7em'), R2, Flags),
+    ml(mstyle_right(R2), R3, Flags),
+    ml(mpadded_right(R3), R, Flags).
+
+mlx(size(A, Size), M, _Flags) :-
+    M = mrow([mstyle([mathsize(Size)], A)]).
+
+mlx(mstyle_right(A), M, _Flags) :-
+    M = mstyle([displaystyle('false'), scriptlevel('0')], A).
+
+mlx(mpadded_right(A), M, _Flags) :-
+    M = mpadded([height('.5em'), width('.5em'), voffset('.9em'), semantics('bspr_prooflabel:right')], A).
+
+mlx(rbicond(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator('%<->%'('R', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(rbicond(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator('%<->%'('R', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(rcond(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator('%->%'('R', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(rcond(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator('%->%'('R', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(rand(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(and('R', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(rand(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator(and('R', '')), R, Flags),
+    M = mrow([F, R]). 
+    
+mlx(ror(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(or('R', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(ror(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator(or('R', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(rneg(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(!('R','')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(rneg(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator(!('R','')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(lbicond(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator('%<->%'('L', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(lbicond(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator('%<->%'('L', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(lcond(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator('%->%'('L', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(lcond(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator('%->%'('L', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(land(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator('&'('L', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(land(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator('&'('L', '')), R, Flags),
+    M = mrow([F, R]).  
+
+mlx(lor(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(or('L', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(lor(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator(or('L', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(lneg(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(!('L', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(lneg(A, B, C), M, Flags) :-
+    ml(proof(A, B, C), F, Flags),
+    ml(format_operator(!('L', '')), R, Flags),
+    M = mrow([F, R]). 
+
+mlx(ax(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(ident('Ax.')), R, [mathvariant(italic)]),
+    M = mrow([F, R]).
+
+mlx(asq(A, B), M, Flags) :-
+    ml(proof(A, B), F, Flags),
+    ml(format_operator(ident('Asq.')), R, [mathvariant(italic)]),
+    M = mrow([mathcolor(red)], [F, R]).
+
+% Render in MathJax
+% jaxx(rcond(A, B), M, Flags) :-
+%     jax(A, A1, Flags),
+%     jax(B, B1, Flags),
+%     format(string(M), "\\frac{~w}{~w}", [B1, A1]).
+

--- a/prolog/bussproofs.pl
+++ b/prolog/bussproofs.pl
@@ -21,72 +21,72 @@
 % math_hook(rcond(A, B), [frac(B, A), '%->%'('R', xx)]).
 
 % Render in MathML
-mlx(proof(Denominator, Numerator), M, Flags) :-
+mathml:mlx(proof(Denominator, Numerator), M, Flags) :-
     X1 =.. ['###1', '##'(Numerator)],
     X =.. ['###2', '##'(X1), '##1'(Denominator)],
     ml(proof_tree(X), M, Flags).
 
-mlx(proof(Denominator, Numerator1, Numerator2), M, Flags) :-
+mathml:mlx(proof(Denominator, Numerator1, Numerator2), M, Flags) :-
     X1 =.. ['###1', '##'(Numerator1, '', Numerator2)],
     X =.. ['###2', '##'(X1), '##1'(Denominator)],
     ml(proof_tree(X), M, Flags).
 
-mlx(format_operator(Op), R, Flags) :-
+mathml:mlx(format_operator(Op), R, Flags) :-
     ml(Op, R1, Flags),
     ml(size(R1, '0.7em'), R2, Flags),
     ml(mstyle_right(R2), R3, Flags),
     ml(mpadded_right(R3), R, Flags).
 
-mlx(size(A, Size), M, _Flags) :-
+mathml:mlx(size(A, Size), M, _Flags) :-
     M = mrow([mstyle([mathsize(Size)], A)]).
 
-mlx(mstyle_right(A), M, _Flags) :-
+mathml:mlx(mstyle_right(A), M, _Flags) :-
     M = mstyle([displaystyle('false'), scriptlevel('0')], A).
 
-mlx(mpadded_right(A), M, _Flags) :-
+mathml:mlx(mpadded_right(A), M, _Flags) :-
     M = mpadded([height('.5em'), width('.5em'), voffset('.9em'), semantics('bspr_prooflabel:right')], A).
 
-mlx(rbicond(A, B), M, Flags) :-
+mathml:mlx(rbicond(A, B), M, Flags) :-
     ml(proof(A, B), F, Flags),
     ml(format_operator('%<->%'('R', '')), R, Flags),
     M = mrow([F, R]).  
 
-mlx(rbicond(A, B, C), M, Flags) :-
+mathml:mlx(rbicond(A, B, C), M, Flags) :-
     ml(proof(A, B, C), F, Flags),
     ml(format_operator('%<->%'('R', '')), R, Flags),
     M = mrow([F, R]).  
 
-mlx(rcond(A, B), M, Flags) :-
+mathml:mlx(rcond(A, B), M, Flags) :-
     ml(proof(A, B), F, Flags),
     ml(format_operator('%->%'('R', '')), R, Flags),
     M = mrow([F, R]).  
 
-mlx(rcond(A, B, C), M, Flags) :-
+mathml:mlx(rcond(A, B, C), M, Flags) :-
     ml(proof(A, B, C), F, Flags),
     ml(format_operator('%->%'('R', '')), R, Flags),
     M = mrow([F, R]).  
 
-mlx(rand(A, B), M, Flags) :-
+mathml:mlx(rand(A, B), M, Flags) :-
     ml(proof(A, B), F, Flags),
     ml(format_operator(and('R', '')), R, Flags),
     M = mrow([F, R]). 
 
-mlx(rand(A, B, C), M, Flags) :-
+mathml:mlx(rand(A, B, C), M, Flags) :-
     ml(proof(A, B, C), F, Flags),
     ml(format_operator(and('R', '')), R, Flags),
     M = mrow([F, R]). 
     
-mlx(ror(A, B), M, Flags) :-
+mathml:mlx(ror(A, B), M, Flags) :-
     ml(proof(A, B), F, Flags),
     ml(format_operator(or('R', '')), R, Flags),
     M = mrow([F, R]). 
 
-mlx(ror(A, B, C), M, Flags) :-
+mathml:mlx(ror(A, B, C), M, Flags) :-
     ml(proof(A, B, C), F, Flags),
     ml(format_operator(or('R', '')), R, Flags),
     M = mrow([F, R]). 
 
-mlx(rneg(A, B), M, Flags) :-
+mathml:mlx(rneg(A, B), M, Flags) :-
     ml(proof(A, B), F, Flags),
     ml(format_operator(!('R','')), R, Flags),
     M = mrow([F, R]). 
@@ -101,57 +101,57 @@ mlx(lbicond(A, B), M, Flags) :-
     ml(format_operator('%<->%'('L', '')), R, Flags),
     M = mrow([F, R]). 
 
-mlx(lbicond(A, B, C), M, Flags) :-
+mathml:mlx(lbicond(A, B, C), M, Flags) :-
     ml(proof(A, B, C), F, Flags),
     ml(format_operator('%<->%'('L', '')), R, Flags),
     M = mrow([F, R]).  
 
-mlx(lcond(A, B), M, Flags) :-
+mathml:mlx(lcond(A, B), M, Flags) :-
     ml(proof(A, B), F, Flags),
     ml(format_operator('%->%'('L', '')), R, Flags),
     M = mrow([F, R]).  
 
-mlx(lcond(A, B, C), M, Flags) :-
+mathml:mlx(lcond(A, B, C), M, Flags) :-
     ml(proof(A, B, C), F, Flags),
     ml(format_operator('%->%'('L', '')), R, Flags),
     M = mrow([F, R]).  
 
-mlx(land(A, B), M, Flags) :-
+mathml:mlx(land(A, B), M, Flags) :-
     ml(proof(A, B), F, Flags),
     ml(format_operator('&'('L', '')), R, Flags),
     M = mrow([F, R]).  
 
-mlx(land(A, B, C), M, Flags) :-
+mathml:mlx(land(A, B, C), M, Flags) :-
     ml(proof(A, B, C), F, Flags),
     ml(format_operator('&'('L', '')), R, Flags),
     M = mrow([F, R]).  
 
-mlx(lor(A, B), M, Flags) :-
+mathml:mlx(lor(A, B), M, Flags) :-
     ml(proof(A, B), F, Flags),
     ml(format_operator(or('L', '')), R, Flags),
     M = mrow([F, R]). 
 
-mlx(lor(A, B, C), M, Flags) :-
+mathml:mlx(lor(A, B, C), M, Flags) :-
     ml(proof(A, B, C), F, Flags),
     ml(format_operator(or('L', '')), R, Flags),
     M = mrow([F, R]). 
 
-mlx(lneg(A, B), M, Flags) :-
+mathml:mlx(lneg(A, B), M, Flags) :-
     ml(proof(A, B), F, Flags),
     ml(format_operator(!('L', '')), R, Flags),
     M = mrow([F, R]). 
 
-mlx(lneg(A, B, C), M, Flags) :-
+mathml:mlx(lneg(A, B, C), M, Flags) :-
     ml(proof(A, B, C), F, Flags),
     ml(format_operator(!('L', '')), R, Flags),
     M = mrow([F, R]). 
 
-mlx(ax(A, B), M, Flags) :-
+mathml:mlx(ax(A, B), M, Flags) :-
     ml(proof(A, B), F, Flags),
     ml(format_operator(ident('Ax.')), R, [mathvariant(italic)]),
     M = mrow([F, R]).
 
-mlx(asq(A, B), M, Flags) :-
+mathml:mlx(asq(A, B), M, Flags) :-
     ml(proof(A, B), F, Flags),
     ml(format_operator(ident('Asq.')), R, [mathvariant(italic)]),
     M = mrow([mathcolor(red)], [F, R]).

--- a/prolog/mathml.pl
+++ b/prolog/mathml.pl
@@ -985,8 +985,12 @@ math(or(A, B), M)
     M = xfy(Prec, or, A, B).
 
 math(!(A), M)
- => current(Prec, xfy, ^),
+ => current(Prec, xfy, ','),
     M = fy(Prec, not, A).
+
+math(!(A, B), M)
+ => current(Prec, xfy, ^),
+    M = xfy(Prec, not, A, B).
 
 math(xor(x=A, y=B), M)
  => M = xor(A, B).
@@ -1087,6 +1091,57 @@ math(Hash, M, _Flags),
     member(Name, ['##', '$$', '%%', '!!'])
  => M = paren(Elements).
 
+% Prooftree: two tables are needed because of different attributes
+
+% For the table with two rows
+ml(proof_tree(A), M, Flags),
+    compound(A),
+    compound_name_arguments(A, Name, Rows),
+    member(Name, ['###2'])
+ => maplist(ml_row(Flags), Rows, R),
+    M = mrow([mtable([align('top 2'), rowlines(solid), framespacing('0 0'), semantics('bspr_inferenceRule:down')], R)]).
+
+% For the table with just one row
+ml(A, M, Flags),
+    compound(A),
+    compound_name_arguments(A, Name, Rows),
+    member(Name, ['###1'])
+ => maplist(ml_row2(Flags), Rows, R),
+    M = mrow([mtable([framespacing('0 0')], R)]).
+
+% Needed to set the attribute of the cell to "rowalign('bottom')"
+ml_row2(Flags, Row, M),
+    compound(Row),
+    compound_name_arguments(Row, Name, Cells),
+    member(Name, ['##', '$$', '%%', '!!'])
+ => maplist(ml_cell2(Flags), Cells, C),
+    M = mtr(C).
+
+ml_cell2(Flags, Cell, M)
+ => ml(Cell, C, Flags),
+    ml(mrow_attribute([semantics('bspr_inference:1;bspr_labelledRule:right')], C), C1, Flags),
+    M = mtd([rowalign('bottom')], C1).
+
+ml(mrow_attribute(Attr, A), M, _Flags)
+ => M = mrow(Attr, [A]).
+
+% Needed to add attributes
+ml_cell3(Flags, Cell, M)
+ => ml(func3(Cell), C, Flags),
+    M = mtd(C).
+
+ml(func3(A), M, Flags) 
+ => ml(A, M1, Flags),
+    %ml(mrow_attribute([data-mjx-textclass('ORD')], M1), M2, Flags),
+    M = mrow(mspace([width('.5ex')], mstyle([displaystyle('false'), scriptlevel('0')], M1))).
+
+/* This should be:
+ M = mrow(mspace([width('.5ex')]), mstyle([displaystyle('false'), scriptlevel('0')], M1)).
+
+so that the resulting line is <mrow><mspace width(".5ex")</mspace> ...</mrow>
+but it raises an error
+*/
+
 % Matrices
 ml(Matrix, M, Flags),
     compound(Matrix),
@@ -1100,6 +1155,14 @@ ml_row(Flags, Row, M),
     compound_name_arguments(Row, Name, Cells),
     member(Name, ['##', '$$', '%%', '!!'])
  => maplist(ml_cell(Flags), Cells, C),
+    M = mtr(C).
+
+% Needed to add attributes with "ml_cell3 (see above)"
+ml_row(Flags, Row, M),
+    compound(Row),
+    compound_name_arguments(Row, Name, Cells),
+    member(Name, ['##1'])
+ => maplist(ml_cell3(Flags), Cells, C),
     M = mtr(C).
 
 ml_cell(Flags, Cell, M)
@@ -1583,6 +1646,15 @@ ml(op('%prop%'), M, _Flags)
 jax(op('%prop%'), M, _Flags)
  => M = "\\propto".
 
+ml(op('%>%'), M, _Flags)
+ => M = mo(&('#x22A2')).
+
+ml(op('%<%'), M, _Flags)
+ => M = mo(&('#x22AC')).
+
+ml(op('%,%'), M, _Flags)
+ => M = mo(',').
+
 ml(op(and), M, _Flags)
  => M = mo(&(and)).
 
@@ -1590,6 +1662,9 @@ jax(op(and), M, _Flags)
  => M = "\\land".
 
 ml(op(or), M, _Flags)
+ => M = mo(&(or)).
+
+ml(op('%|%'), M, _Flags)
  => M = mo(&(or)).
 
 jax(op(or), M, _Flags)
@@ -1600,6 +1675,9 @@ ml(op(not), M, _Flags)
 
 jax(op(not), M, _Flags)
  => M = "\\lnot".
+
+ml(op(~), M, _Flags)
+ => M = mo(&(not)).
 
 ml(op(veebar), M, _Flags)
  => M = mo(&(veebar)).
@@ -1845,6 +1923,34 @@ math('%=~%'(A, B), X)
 math('%prop%'(A, B), X)
  => current_op(Prec, xfx, =),
     X = yfy(Prec, '%prop%', A, B).
+
+math('%>%'(A), X)
+ => current_op(Prec, xfy, ';'),
+    X = fy(Prec, '%>%', A).
+
+math('%>%'(A, B), X)
+ => current_op(Prec, xfy, ';'),
+    X = yfy(Prec, '%>%', A, B).
+
+math('%<%'(A), X)
+ => current_op(Prec, xfy, ','),
+    X = fy(Prec, '%<%', A).
+
+math('%<%'(A, B), X)
+ => current_op(Prec, xfy, ','),
+    X = yfy(Prec, '%<%', A, B).
+
+math('%,%'(A, B), X)
+ => current_op(Prec, xfy, ','),
+    X = yfy(Prec, '%,%', A, B).
+
+math('%|%'(A, B), X)
+ => current_op(Prec, xfy, ';'),
+    X = yfy(Prec, '%|%', A, B).
+
+math(~(A), X)
+ => current_op(Prec, fy, \+),
+    X = fy(Prec, ~, A).
 
 math(A > B, X)
  => current_op(Prec, xfx, >),

--- a/tests/test-bussproofs.Rmd
+++ b/tests/test-bussproofs.Rmd
@@ -3,79 +3,79 @@ library(mathml)
 rolog::consult(system.file(file.path("pl", "bussproofs.pl"), package="mathml"))
 
 # 1. Excluded middle
-term <- quote(ror(''%>%A%|%~A, rneg(''%>%A%,%~A, ax(A%>%A,''))))
-#math(term)
+term <- quote(ror('%>%'('', '%|%'(A, ~A)), rneg('%>%'('', '%,%'(A, ~A)), ax('%>%'(A, A), ''))))
+math(term)
 
-# 2. Dilemma
-term <- quote(rcond(''%>%((~A%->%B)&(A%->%B))%->%B, land((~A%->%B)&(A%->%B)%>%B, 
-lcond(~A%>%B%,%A%->%B%>%B, 
-rneg(A%->%B%>%~A%,%B, 
-lcond(A%,%A%->%B%>%B, 
-ax(A%>%A%,%B, ''), ax(B%,%A%>%B, ''))), 
-ax(B%,%A%->%B%>%B, '' )))))
+# 2. Dilemma 
+term <- quote(rcond('%>%'('%->%'(('&'('%->%'(~A, B), '%->%'(A, B))), B)), land('%>%'('&'('%->%'(~A, B),'%->%'(A, B)), B), 
+lcond('%>%'('%->%'('%->%'(~A, '%,%'(B, A)), B), B), 
+rneg('%>%'('%->%'(A, B), '%,%'(~A, B)), 
+lcond('%>%'('%->%'('%,%'(A, A), B), B), 
+ax('%>%'(A, '%,%'(A, B)), ''), ax('%>%'('%,%'(B, A), B), ''))), 
+ax('%>%'('%->%'('%,%'(B, A), B), B), '')))))
 math(term)
 
 # 3. Double negation
-term <- quote(rbicond(''%>%~~A%<=>%A, 
-lneg(~~A%>%A, 
-rneg(''%>%~A%,%A, 
-ax(A%>%A, ''))), 
-rneg(A%>%~~A, 
-lneg(~A%,%A%>%'', 
-ax(A%>%A, '')))))
+term <- quote(rbicond('%>%'('%<=>%'(~~A, A)), 
+lneg('%>%'(~~A, A), 
+rneg('%>%'('%,%'(~A, A)), 
+ax('%>%'(A, A), ''))), 
+rneg('%>%'(A, ~~A), 
+lneg('%>%'('%,%'(~A, A), ''), 
+ax('%>%'(A, A), '')))))
 math(term)
 
 # 4. Peirce's Law
-term <- quote(rcond(''%>%((A%->%B)%->%A)%->%A, 
-lcond((A%->%B)%->%A%>%A, 
-rcond(''%>%A%->%B%,%A, 
-ax(A%>%B%,%A, '')), 
-ax(A%>%A, ''))))
+term <- quote(rcond('%>%'('%->%'(('%->%'(('%->%'(A, B)), A)), A)), 
+lcond('%>%'('%->%'(('%->%'(A, B)), A), A), 
+rcond('%>%'('%->%'(A, '%,%'(B, A))), 
+ax('%>%'(A, '%,%'(B, A)), '')), 
+ax('%>%'(A, A), ''))))
 math(term)
 
 # 5. Dummett Formula
-term <-quote(ror(''%>%(A%->%B)%|%(B%->%A), 
-rcond(''%>%A%->%B%,%B%->%A, 
-rcond(A%>%B%,%B%->%A, 
-ax(B%,%A%>%A%,%B, '')))))
+term <-quote(ror('%>%'('%|%'(('%->%'(A, B)), ('%->%'(B, A)))), 
+rcond('%>%'('%->%'(A, '%->%'('%,%'(B, B), A))), 
+rcond('%>%'('%->%'(A, '%->%'('%,%'(B, B), A))), 
+ax('%>%'('%,%'(B, A), '%,%'(A, B)), '')))))
 math(term)
 
 # 6. Classical equivalence for negation
-term <- quote(rbicond(''%>%(~A%->%A)%<=>%A, 
-lcond(~A%->%A%>%A, 
-rneg(''%>%~A%,%A, 
-ax(A%>%A, '')), 
-ax(A%>%A, '')), 
-rcond(A%>%~A%->%A, 
-ax(~A%,%A%>%A, ''))))
+term <- quote(rbicond('%>%'('%<=>%'(('%->%'(~A, A)), A)), 
+lcond('%>%'('%->%'(~A, A), A), 
+rneg('%>%'('%,%'(~A, A)), 
+ax('%>%'(A, A), '')), 
+ax('%>%'(A, A), '')), 
+rcond('%>%'(A, '%->%'(~A, A)), 
+ax('%>%'('%,%'(~A, A), A), ''))))
 math(term)
 
 # 7. Classical De Morgan's Law
-term <- quote(rcond(''%>%~(A&B)%->%(~A%|%~B), 
-ror(~(A&B)%>%~A%|%~B, 
-rneg(~(A&B)%>%~A%,%~B, 
-rneg(A%,%~(A&B)%>%~B, 
-lneg(B%,%A%,%~(A&B)%>%'', 
-rand(B%,%A%>%A&B, 
-ax(B%,%A%>%A, ''), 
-ax(B%,%A%>%B, ''))))))))
+term <- quote(rcond('%>%'('%->%'(~('&'(A,B)), '%|%'(~A, ~B))), 
+ror('%>%'(~('&'(A, B)), '%|%'(~A, ~B)), 
+rneg('%>%'(~('&'(A, B)), '%,%'(~A, ~B)), 
+rneg('%>%'('%,%'(A, ~('&'(A, B))), ~B), 
+lneg('%>%'('%,%'('%,%'(B, A), ~('&'(A, B))), ''), 
+rand('%>%'('%,%'(B, A), '&'(A, B)), 
+ax('%>%'('%,%'(B, A), A), ''), 
+ax('%>%'('%,%'(B, A), A), ''))))))))
 math(term)
 
 # 9. a
-term <- quote(asq(''%<%A, ''))
+term <- quote(asq('%<%'(A), ''))
 math(term)
 
 # 10. a => b
-term <- quote(rcond(''%>%A%->%B, asq(A%<%B, '')))
+term <- quote(rcond('%>%'('%->%'(A, B)), asq('%<%'(A, B), '')))
 math(term)
 
 # 11. (a | b) => (a & b)
-term <- quote(rcond(''%>%(A%|%B)%->%(A&B), 
-rand(A%|%B%>%A&B, 
-lor(A%|%B%>%A, ax(A%>%A, ''), 
+term <- quote(rcond('%>%'('%->%'('%|%'(A, B), ('&'(A, B)))), 
+rand('%>%'('%|%'(A, B), '&'(A, B)), 
+lor('%>%'('%|%'(A, B), A), ax('%>%'(A, A), ''), 
     asq(B%<%A, '')), 
-lor(A%|%B%>%B, asq(A%<%B, ''), 
-    ax(B%>%B, '')))))
+lor(A%|%B%>%B, asq('%<%'(A, B), ''), 
+    ax('%>%'(B, B), '')))))
 math(term)
 
 ```

--- a/vignettes/mathml.Rmd
+++ b/vignettes/mathml.Rmd
@@ -861,9 +861,10 @@ or `a^(1.0/3L)` with a floating point number in the numerator are not detected.
 
 ## Proofs
 _Mathml_ provides a basic representation for proof trees in the sequent calculus. 
-The supported predicates are 'rcond/2', 'land/2', and 'ax/2'. The first argument contains
-the expression for one line and the second argument for everything above it (which can be
-another predicate of these).
+The supported predicates are 'rbicond', 'rcond', 'rand', 'ror', 'rneg', 'lbicond', 
+'lcond', 'land', 'lor', 'lneg', each of which both in the variant with 2 and 3 arguments. 
+The first argument contains the expression for one line and the other arguments for everything above it (which can be other predicate of these). To prevent the precedence setting by R and instead enable 
+the precedences defined in Prolog, the prefix notation should be used.
 
 ```{r}
 rolog::consult(system.file(file.path("pl", "bussproofs.pl"), package="mathml"))
@@ -871,7 +872,20 @@ rolog::consult(system.file(file.path("pl", "bussproofs.pl"), package="mathml"))
 term <- quote(rcond(A, B))
 math(term)
 
-term <- quote(rcond(''%>%(A&B)%=>%A, land(A&B%>%A, ax(A%,%B%>%A,''))))
+term <- quote(ror('%>%'('', '%|%'(A, ~A)), 
+rneg('%>%'('', '%,%'(A, ~A)), 
+ax('%>%'(A, A), ''))))
+math(term)
+
+term <- quote(
+rcond('%>%'('%->%'('%|%'(A, B), ('&'(A, B)))), 
+rand('%>%'('%|%'(A, B), '&'(A, B)), 
+lor('%>%'('%|%'(A, B), A), 
+    ax('%>%'(A, A), ''), 
+    asq(B%<%A, '')), 
+lor(A%|%B%>%B, 
+    asq('%<%'(A, B), ''), 
+    ax('%>%'(B, B), '')))))
 math(term)
 ```
 


### PR DESCRIPTION
I changed the example file to prefix notation. Now all the parentheses are correct, except when they are nested: here a square bracket is rendered instead of a round one. 

![image](https://github.com/mgondan/mathml/assets/149394139/3d5abb4d-4a51-4163-8372-f77411031402)

Then I copied 'bussproofs.pl' into the prolog directory and added the module header.

Is it the right way of testing it, if I write a query in prolog like:
?- pl_mathml(rbicond(A, B), M, []).

after pushing all the changes to the remote repo and then cloning it via 'pack_install('GIT-url').'
Because I get this error:

![image](https://github.com/mgondan/mathml/assets/149394139/2f3851d7-ed1d-4400-b50f-f2382e95bafc)


