### PR TITLE
Use option digits instead of round

### DIFF
--- a/inst/pl/mathml.pl
+++ b/inst/pl/mathml.pl
@@ -1761,15 +1761,15 @@ ml(pos(1.0Inf), M, _Flags)
 % Default number of decimals is getOption("digits") from R
 math(round(A, D), M, Flags0, Flags1)
  => M = A,
-    Flags1 = [round(D) | Flags0].
+    Flags1 = [digits(D) | Flags0].
 
 digits(Flags, D),
     r_eval(getOption("digits"), Default),
     integer(Default)
- => option_(round(D), Flags, Default).
+ => option_(digits(D), Flags, Default).
 
 digits(Flags, D)
- => option_(round(D), Flags, 2).
+ => option_(digits(D), Flags, 2).
 
 ml(pos(A), M, Flags)
  => digits(Flags, D),

--- a/prolog/mathml.pl
+++ b/prolog/mathml.pl
@@ -1763,10 +1763,10 @@ ml(pos(1.0Inf), M, _Flags)
 % Default number of decimals is 2, change it using Flags
 math(round(A, D), M, Flags0, Flags1)
  => M = A,
-    Flags1 = [round(D) | Flags0].
+    Flags1 = [digits(D) | Flags0].
 
 ml(pos(A), M, Flags)
- => option_(round(D), Flags, 2),
+ => option_(digits(D), Flags, 2),
     format(atom(Mask), '~~~wf', [D]),
     format(string(X), Mask, [A]),
     M = mn(X).
@@ -1778,7 +1778,7 @@ jax(pos(1.0Inf), M, _Flags)
  => M = "\\infty".
 
 jax(pos(A), M, Flags)
- => option_(round(D), Flags, 2),
+ => option_(digits(D), Flags, 2),
     format(atom(Mask), '~~~wf', [D]),
     format(string(M), Mask, [A]).
 


### PR DESCRIPTION
Before:
?- pl_mathml(1.2356, M, [round(3)]).
M = ["<", "math", ">", "<", "mn", ">", "1.236", "</", "mn"|...].

?- pl_mathml(1.2356, M, [digits(3)]).    % not defined -> default
M = ["<", "math", ">", "<", "mn", ">", "1.24", "</", "mn"|...].




After:
?- pl_mathml(1.2356, M, [round(3)]).  % not defined -> default
M = ["<", "math", ">", "<", "mn", ">", "1.24", "</", "mn"|...].

?- pl_mathml(1.2356, M, [digits(3)]).  
M = ["<", "math", ">", "<", "mn", ">", "1.236", "</", "mn"|...].