### PR TITLE
Added test for digits 

### DIFF
--- a/tests/testthat/test-mathml.R
+++ b/tests/testthat/test-mathml.R
@@ -869,3 +869,9 @@ test_that("Tdiamond",
             q <- mathml(quote(T^diamond))
             expect_equal(q, "<math><msup><mi>T</mi><mi>&diamond;</mi></msup></math>")
           })
+
+test_that("digits",
+          {
+            q <- mathml(quote(3.14159265), flags=list(quote(digits(4L))))
+            expect_equal(q, "<math><mn>3.1416</mn></math>")
+          })


### PR DESCRIPTION
After adding this test, how should I "check if the vignette uses round/digits"?

The only occurrences of "round" in mathml.Rmd are here:

> Lines 121-135
> ```{r}
> term <- quote(1 + -2L + a + abc + "a" + phi + Phi + varphi + roof(b)[i, j]^2L)
> math(term)
> 
> term <- quote(round(3.1415, 3L) + NaN + NA + TRUE + FALSE + Inf + (-Inf))
> math(term)
> ```
> An expression such as `1 + -2` may be considered unsatisfactory from an
> aesthetic perspective. It is correct R\ syntax, though, and is reproduced
> accordingly, without the parentheses. Parentheses around negated numbers or
> symbols can be added as shown above for `+ (-Inf)`. If `round` is not given,
> R's default number of decimals from `getOption("digits")` is used (which is way
> too large in the author's opinion---in line with the unfortunate practice of
> statistics programs). "

But in "term <- quote(round(3.1415, 3L) ..." , "round" refers to the function from R base and not to the flag , right?

So, what are the relevant sections to look for? 