### PR TITLE
Internal `knitr:::escape_html()` -> exported `xfun::html_escape()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,8 @@ Depends:
     R (>= 4.2),
     rolog (>= 0.9.14),
     knitr
+Imports:
+    xfun (>= 0.48)
 Encoding: UTF-8
 URL: https://github.com/mgondan/mathml
 BugReports: https://github.com/mgondan/mathml/issues

--- a/rj/mathml.Rmd
+++ b/rj/mathml.Rmd
@@ -267,10 +267,10 @@ escape <- function(s)
   }
   
   if(knitr::is_html_output())
-    return(sapply(s, FUN=knitr:::escape_html))
+    return(sapply(s, FUN=xfun::html_escape))
   
   warning("escape: no knitr output specified")
-  sapply(s, FUN=knitr:::escape_html)
+  sapply(s, FUN=xfun::html_escape)
 }
 
 op1 <- list(

--- a/vignettes/mathml.Rmd
+++ b/vignettes/mathml.Rmd
@@ -246,7 +246,7 @@ op1 <- names(op1)
 if(knitr::is_latex_output())
   op1 <- sapply(op1, FUN=knitr:::escape_latex)
 if(knitr::is_html_output())
-  op1 <- sapply(op1, FUN=knitr:::escape_html)
+  op1 <- sapply(op1, FUN=xfun::html_escape)
 
 op2 <- list(
   "A\\ !=\\ B"=quote(A != B),
@@ -267,7 +267,7 @@ op2 <- names(op2)
 if(knitr::is_latex_output())
   op2 <- sapply(op2, FUN=knitr:::escape_latex)
 if(knitr::is_html_output())
-  op2 <- sapply(op2, FUN=knitr:::escape_html)
+  op2 <- sapply(op2, FUN=xfun::html_escape)
 
 op3 <- list(
   "A\\ %<->%\\ B"=quote(A %<->% B),
@@ -288,7 +288,7 @@ op3 <- names(op3)
 if(knitr::is_latex_output())
   op3 <- sapply(op3, FUN=knitr:::escape_latex)
 if(knitr::is_html_output())
-  op3 <- sapply(op3, FUN=knitr:::escape_html)
+  op3 <- sapply(op3, FUN=xfun::html_escape)
 
 t <- cbind(Operator=op1, Output=m1,
   Operator=op2, Output=m2,
@@ -336,7 +336,7 @@ op1 <- names(op1)
 if(knitr::is_latex_output())
   op1 <- sapply(op1, FUN=knitr:::escape_latex)
 if(knitr::is_html_output())
-  op1 <- sapply(op1, FUN=knitr:::escape_html)
+  op1 <- sapply(op1, FUN=xfun::html_escape)
 
 op2 <- list(
   "dbinom(k,\\ N,\\ pi)"=quote(dbinom(k, N, pi)),
@@ -361,7 +361,7 @@ op2 <- names(op2)
 if(knitr::is_latex_output())
   op2 <- sapply(op2, FUN=knitr:::escape_latex)
 if(knitr::is_html_output())
-  op2 <- sapply(op2, FUN=knitr:::escape_html)
+  op2 <- sapply(op2, FUN=xfun::html_escape)
 
 t <- cbind(Function=op1, Output=m1, Function=op2, Output=m2)
 knitr::kable(t, caption="Table 2. R functions from _base_ and _stats_",
@@ -596,7 +596,7 @@ op1 <- names(op1)
 if(knitr::is_latex_output())
   op1 <- sapply(op1, FUN=knitr:::escape_latex)
 if(knitr::is_html_output())
-  op1 <- sapply(op1, FUN=knitr:::escape_html)
+  op1 <- sapply(op1, FUN=xfun::html_escape)
 
 t <- cbind(Operation=op1, 
   "error\\ =\\ asis"=asis, highlight=high, fix=fix, ignore=igno)


### PR DESCRIPTION
This internal function may be removed in the future: https://github.com/yihui/knitr/commit/0f59bbabb98a49bb76f2b222cd103d8998454acc#diff-60bef5af43a1bd541299ce9bceeb226afb23deaa5e637b145c85e05ffd552b0c